### PR TITLE
Fix typo in token param description

### DIFF
--- a/cloner/cli.py
+++ b/cloner/cli.py
@@ -33,7 +33,7 @@ def setup_logging(level: str) -> None:
     "token",
     type=str,
     default=None,
-    help="GitHub token to read private repos. This parameter is needed when cloning from an GitHub Enterprise server.",
+    help="GitHub token to read private repos. This parameter is needed when cloning from a GitHub Enterprise server.",
     show_default=True,
 )
 @click.option(


### PR DESCRIPTION
## What?
Fix typo in `--token` param description.

## Checklist
- [x] Label added to the PR
- [x] PR up to date with default branch
- [x] All checks are green
