### PR TITLE
Remove custom labels from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       interval: "monthly"
     assignees:
       - "w0rmr1d3r"
-    labels:
-      - "bump"
     reviewers:
       - "w0rmr1d3r"
     open-pull-requests-limit: 10
@@ -22,8 +20,6 @@ updates:
       interval: "monthly"
     assignees:
       - "w0rmr1d3r"
-    labels:
-      - "bump"
     reviewers:
       - "w0rmr1d3r"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## What?
Remove custom labels for dependabot

## Checklist
- [x] Label added to the PR
- [ ] PR up to date with default branch
- [ ] All checks are green
