### PR TITLE
Replace some dev tools with ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,14 @@ install-dev:
 	pip install -r requirements-dev.txt
 
 format:
-	# run autoflake first, so empty spaces are fixed by other tools
-	autoflake --remove-all-unused-imports --remove-duplicate-keys --remove-unused-variables -v -r -i cloner/
-	isort --float-to-top .
+	ruff --fix .
 	black .
 	docformatter --in-place --recursive .
 
 lint:
-	autoflake --remove-all-unused-imports --remove-duplicate-keys --remove-unused-variables --quiet -r -c cloner/
-	isort --check-only .
+	ruff check .
 	black --check .
 	docformatter --check --recursive .
-	flake8 .
 
 unit:
 	pytest -svvv tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,17 +45,15 @@ dependencies = [
 [project.optional-dependencies]
 # Always try to be compatible with these versions and above
 dev = [
-    "autoflake>=2.0.0",
     "black>=22.3.0",
     "coverage>=6.3.2",
     "docformatter>=1.5.1",
     "faker>=12.0.1",
-    "flake8>=6.0.0",
-    "isort>=5.10.0",
     "pip-tools>=6.5.0",
     "pylint>=2.15.10",
     "pytest>=6.2.5",
-    "responses>=0.20.0"
+    "responses>=0.20.0",
+    "ruff>=0.0.270"
 ]
 
 [project.scripts]
@@ -81,12 +79,9 @@ exclude = '''
 )/
 '''
 
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-combine_as_imports = true
-line_length = 120
+[tool.ruff]
+select = ["E", "F", "I"]
+line-length = 120
 
 [tool.pylint.'MESSAGES CONTROL']
 # C0114 - missing module docstring - does not apply (yet)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,6 @@
 #
 astroid==2.15.5
     # via pylint
-autoflake==2.1.1
-    # via wr-cloner (pyproject.toml)
 black==23.3.0
     # via wr-cloner (pyproject.toml)
 build==0.10.0
@@ -35,22 +33,16 @@ exceptiongroup==1.1.1
     # via pytest
 faker==18.9.0
     # via wr-cloner (pyproject.toml)
-flake8==6.0.0
-    # via wr-cloner (pyproject.toml)
 idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
 isort==5.12.0
-    # via
-    #   pylint
-    #   wr-cloner (pyproject.toml)
+    # via pylint
 lazy-object-proxy==1.9.0
     # via astroid
 mccabe==0.7.0
-    # via
-    #   flake8
-    #   pylint
+    # via pylint
 mypy-extensions==1.0.0
     # via black
 packaging==23.1
@@ -68,12 +60,6 @@ platformdirs==3.5.1
     #   pylint
 pluggy==1.0.0
     # via pytest
-pycodestyle==2.10.0
-    # via flake8
-pyflakes==3.0.1
-    # via
-    #   autoflake
-    #   flake8
 pylint==2.16.4
     # via wr-cloner (pyproject.toml)
 pyproject-hooks==1.0.0
@@ -82,26 +68,27 @@ pytest==7.3.1
     # via wr-cloner (pyproject.toml)
 python-dateutil==2.8.2
     # via faker
+pyyaml==6.0
+    # via responses
 requests==2.31.0
     # via
     #   responses
     #   wr-cloner (pyproject.toml)
 responses==0.23.1
     # via wr-cloner (pyproject.toml)
+ruff==0.0.270
+    # via wr-cloner (pyproject.toml)
 six==1.16.0
     # via python-dateutil
-toml==0.10.2
-    # via responses
 tomli==2.0.1
     # via
-    #   autoflake
     #   black
     #   build
     #   pylint
     #   pytest
 tomlkit==0.11.8
     # via pylint
-types-toml==0.10.8.6
+types-pyyaml==6.0.12.10
     # via responses
 typing-extensions==4.6.2
     # via

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 120


### PR DESCRIPTION
## What?
Replacing `isort`, `flake8` and `autoflake` with `ruff`

## Checklist
- [x] Type of change label added
