### PR TITLE
Fix KeyError on unnecessary repo value when adding it to the queue

### DIFF
--- a/cloner/put_repos_in_queue.py
+++ b/cloner/put_repos_in_queue.py
@@ -10,14 +10,19 @@ def put_repos_in_queue(
     queue_lock: threading.Lock,
     repo_queue: queue.Queue,
 ) -> None:
-    """Puts into the queue repositories obtained from a dictionary Each element
-    of the json_response is a dictionary containing the GitHub response with
-    repository information."""
+    """Puts into the queue repositories obtained from a dictionary.
+
+    Each element of the json_response is a dictionary containing the
+    GitHub response with repository information.
+
+    Raises `KeyError` in case the `cloner_url` in a response doesn't
+    exist
+    """
     queue_lock.acquire()
     for repo_number in range(len(json_response)):
         repo_queue.put(
             Repository(
-                name=json_response[repo_number]["name"],
+                name=json_response[repo_number].get("name", ""),
                 clone_url=json_response[repo_number]["clone_url"],
                 repo_id=repo_number,
             )

--- a/tests/test_put_repos_in_queue.py
+++ b/tests/test_put_repos_in_queue.py
@@ -1,26 +1,44 @@
+import pytest
+from _pytest.python_api import raises
+
 from cloner.put_repos_in_queue import put_repos_in_queue
 from cloner.repository import Repository
 
 
-def test_put_repos_into_queue_puts_obtained_repos_as_repositories_into_a_given_queue(queue_lock, repository_list_queue):
-    test_json_response = [
-        {
-            "name": "test_name",
-            "clone_url": "https://github.com/organisation/test_name.git",
-        }
-    ]
-    expected_repository = Repository(
-        name="test_name",
-        clone_url="https://github.com/organisation/test_name.git",
-        repo_id=0,
-    )
-
+@pytest.mark.parametrize(
+    "json_response,expected_repository",
+    [
+        (
+            [
+                {
+                    "name": "test_name",
+                    "clone_url": "https://github.com/organisation/test_name.git",
+                }
+            ],
+            Repository(
+                name="test_name",
+                clone_url="https://github.com/organisation/test_name.git",
+                repo_id=0,
+            ),
+        ),
+        (
+            [
+                {
+                    "clone_url": "https://github.com/organisation/test_name.git",
+                }
+            ],
+            Repository(name="", clone_url="https://github.com/organisation/test_name.git", repo_id=0),
+        ),
+    ],
+)
+def test_put_repos_into_queue_missing_some_values_in_answer(
+    json_response, expected_repository, queue_lock, repository_list_queue
+):
     put_repos_in_queue(
-        json_response=test_json_response,
+        json_response=json_response,
         queue_lock=queue_lock,
         repo_queue=repository_list_queue,
     )
-
     assert len(repository_list_queue.queue) == 1
     assert repository_list_queue.get() == expected_repository
 
@@ -35,3 +53,19 @@ def test_put_repos_into_queue_does_nothing_if_no_answer_obtained(queue_lock, rep
     )
 
     assert len(repository_list_queue.queue) == 0
+
+
+def test_threads_below_1_raises_error(
+    queue_lock,
+    repository_list_queue,
+):
+    with raises(KeyError):
+        put_repos_in_queue(
+            json_response=[
+                {
+                    "name": "test_name",
+                }
+            ],
+            queue_lock=queue_lock,
+            repo_queue=repository_list_queue,
+        )


### PR DESCRIPTION
## What?
Name is not required when adding a repo name to the queue. Solving a KeyError there.
If clone_url is not present, it will raise the error.

## Checklist
- [x] Type of change label added
