### PR TITLE
Bump ruff to 0.1.15 and update its constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
     "pylint>=2.15.10",
     "pytest>=6.2.5",
     "responses>=0.20.0",
-    "ruff>=0.0.270"
+    "ruff==0.1.15" # still in 0.x introducing breaking changes
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -78,7 +78,7 @@ requests==2.32.3
     #   wr-cloner (pyproject.toml)
 responses==0.25.3
     # via wr-cloner (pyproject.toml)
-ruff==0.1.7
+ruff==0.1.15
     # via wr-cloner (pyproject.toml)
 six==1.16.0
     # via python-dateutil


### PR DESCRIPTION
## What?
Bump ruff to 0.1.15 and update its constraint since it's introducing breaking changes.

## Checklist
- [x] Type of change label added
